### PR TITLE
feat: Add EmailProvider and SmsProvider configuration via environment variables

### DIFF
--- a/server/README.md
+++ b/server/README.md
@@ -252,8 +252,16 @@ export APPLE_SERVICE_ID=com.yourcompany.yourapp.service  # Optional: For web/And
 
 Required for email OTP verification:
 
+**Fake**
+Prints to stdout instead of sending emails.
+
+```bash
+export EMAIL_PROVIDER=fake
+```
+
 ```bash
 # Currently supports SendGrid
+export EMAIL_PROVIDER=sendgrid
 export SENDGRID_API_KEY=your_sendgrid_api_key
 export SENDGRID_BASE_URL=https://api.sendgrid.com  # Optional, defaults to SendGrid API
 ```
@@ -281,9 +289,17 @@ When `PASSWORD_RESET_TEMPLATE_ID` is set, the handler will use Sendgrid dynamic 
 
 Required for SMS OTP verification. Choose one provider:
 
+**Fake**
+Prints to stdout instead of sending SMS.
+
+```bash
+export SMS_PROVIDER=fake
+```
+
 **Twilio**
 
 ```bash
+export SMS_PROVIDER=twilio
 export TWILIO_ACCOUNT_SID=your_twilio_account_sid
 export TWILIO_AUTH_TOKEN=your_twilio_auth_token
 export TWILIO_MESSAGING_SERVICE_SID=your_messaging_service_sid
@@ -292,6 +308,7 @@ export TWILIO_MESSAGING_SERVICE_SID=your_messaging_service_sid
 **TextBelt**
 
 ```bash
+export SMS_PROVIDER=textbelt
 export TEXTBELT_API_KEY=your_textbelt_api_key
 ```
 

--- a/server/pubspec.lock
+++ b/server/pubspec.lock
@@ -525,10 +525,10 @@ packages:
     dependency: "direct main"
     description:
       name: super_simple_authentication_toolkit
-      sha256: "5bf25a584ac66be00687fcb1d56a94dc41930133960e768d219f557df86606a4"
+      sha256: "92efa54b61dc10a0ad35cc0659a3ba1e712cc531cd16962f92c4c164dc22c7f9"
       url: "https://pub.dev"
     source: hosted
-    version: "0.0.1-dev.5"
+    version: "0.0.1-dev.7"
   term_glyph:
     dependency: transitive
     description:

--- a/server/pubspec.yaml
+++ b/server/pubspec.yaml
@@ -11,7 +11,7 @@ dependencies:
   mason_logger: ^0.3.3
   super_simple_authentication_hive_data_storage: 0.0.1-dev.2
   super_simple_authentication_postgres_data_storage: 0.0.1-dev.3
-  super_simple_authentication_toolkit: 0.0.1-dev.5
+  super_simple_authentication_toolkit: 0.0.1-dev.7
 
 dev_dependencies:
   json_serializable: ^6.11.3

--- a/server/routes/_middleware.dart
+++ b/server/routes/_middleware.dart
@@ -13,6 +13,41 @@ Handler middleware(Handler handler) {
       .use(provider((_) => logger))
       .use(apiKeyMiddleware(apiKey: Platform.environment['API_KEY']))
       .use(
+        provider((_) {
+          return switch (Platform.environment['EMAIL_PROVIDER']) {
+            'fake' => FakeEmailService(stdout: stdout),
+            'sendgrid' => Sendgrid(
+              apiKey: Platform.environment['SENDGRID_API_KEY']!,
+              baseUrl: Platform.environment['SENDGRID_BASE_URL']!,
+            ),
+            _ =>
+              throw Exception(
+                '''Invalid email provider: ${Platform.environment['EMAIL_PROVIDER']}''',
+              ),
+          };
+        }),
+      )
+      .use(
+        provider((_) {
+          return switch (Platform.environment['SMS_PROVIDER']) {
+            'fake' => FakeSms(stdout: stdout),
+            'twilio' => Twilio(
+              accountSid: Platform.environment['TWILIO_ACCOUNT_SID']!,
+              authenticationToken: Platform.environment['TWILIO_AUTH_TOKEN']!,
+              messagingServiceSid:
+                  Platform.environment['TWILIO_MESSAGING_SERVICE_SID']!,
+            ),
+            'textbelt' => Textbelt(
+              apiKey: Platform.environment['TEXTBELT_API_KEY']!,
+            ),
+            _ =>
+              throw Exception(
+                '''Invalid SMS provider: ${Platform.environment['SMS_PROVIDER']}''',
+              ),
+          };
+        }),
+      )
+      .use(
         corsMiddleware(
           allowedOrigin: Platform.environment['ALLOWED_ORIGIN'],
           allowedMethods: ['GET', 'POST', 'PUT', 'DELETE', 'OPTIONS'],


### PR DESCRIPTION
## Summary

This PR adds support for configuring email and SMS providers via environment variables, integrating with the new `EmailProvider` and `SmsProvider` interfaces introduced in the toolkit.

## Changes

- **Added `EMAIL_PROVIDER` environment variable support:**
  - `fake` - Uses `FakeEmailService` for testing (prints to stdout)
  - `sendgrid` - Uses `Sendgrid` provider

- **Added `SMS_PROVIDER` environment variable support:**
  - `fake` - Uses `FakeSms` for testing (prints to stdout)
  - `twilio` - Uses `Twilio` provider
  - `textbelt` - Uses `Textbelt` provider

- **Updated middleware:**
  - Added providers for `EmailProvider` and `SmsProvider` based on environment variables
  - Providers are injected into the request context for use by handlers

- **Updated documentation:**
  - Added README.md documentation for new provider configuration options
  - Documented all supported provider types

- **Updated dependencies:**
  - Updated `super_simple_authentication_toolkit` to version 0.0.1-dev.7

## Testing

- ✅ Code formatted with `dart format`
- ✅ Linter passed with no errors
- ✅ Middleware properly configures providers based on environment variables