### PR TITLE
fix: Add Now provider to middleware

### DIFF
--- a/server/routes/_middleware.dart
+++ b/server/routes/_middleware.dart
@@ -9,6 +9,7 @@ Handler middleware(Handler handler) {
   return handler
       .use(requestLogger())
       .use(rateLimitMiddleware())
+      .use(provider<Now>((_) => DateTime.now()))
       .use(provider((_) => dataStorage))
       .use(provider((_) => logger))
       .use(apiKeyMiddleware(apiKey: Platform.environment['API_KEY']))


### PR DESCRIPTION
This PR adds a Now provider to the middleware that provides DateTime.now() for dependency injection.