### PR TITLE
fix: nullable password and salt fields in Postgres data storage

### DIFF
--- a/server/packages/super_simple_authentication_postgres_data_storage/CHANGELOG.md
+++ b/server/packages/super_simple_authentication_postgres_data_storage/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.0.1-dev.4
+
+- Fix nullable password and salt fields in `User` type
+
 ## 0.0.1-dev.3
 
 - Add password reset functionality

--- a/server/packages/super_simple_authentication_postgres_data_storage/lib/src/postgres_data_storage.dart
+++ b/server/packages/super_simple_authentication_postgres_data_storage/lib/src/postgres_data_storage.dart
@@ -198,9 +198,9 @@ class PostgresDataStorage extends DataStorage {
         .map(
           (row) => (
             id: row[0]! as String,
-            email: row[1]! as String,
-            hashedPassword: row[2]! as String,
-            salt: row[3]! as String,
+            email: row[1]! as String?,
+            hashedPassword: row[2] as String?,
+            salt: row[3] as String?,
             phoneNumber: null,
           ),
         )
@@ -225,8 +225,8 @@ class PostgresDataStorage extends DataStorage {
             id: row[0]! as String,
             email: null,
             phoneNumber: row[1]! as String,
-            hashedPassword: row[2]! as String,
-            salt: row[3]! as String,
+            hashedPassword: row[2] as String?,
+            salt: row[3] as String?,
           ),
         )
         .toList();

--- a/server/packages/super_simple_authentication_postgres_data_storage/pubspec.yaml
+++ b/server/packages/super_simple_authentication_postgres_data_storage/pubspec.yaml
@@ -1,6 +1,6 @@
 name: super_simple_authentication_postgres_data_storage
 description: A DataStorage that stores information to Postgres
-version: 0.0.1-dev.3
+version: 0.0.1-dev.4
 repository: https://github.com/mtwichel/super_simple_flutter_authentication/tree/main/packages/super_simple_authentication_postgres_data_storage
 
 environment:

--- a/server/pubspec.lock
+++ b/server/pubspec.lock
@@ -517,10 +517,10 @@ packages:
     dependency: "direct main"
     description:
       name: super_simple_authentication_postgres_data_storage
-      sha256: e033c2ca90ca625215b8509b1b80d8ca58379685f2c536bdecdf2578926f29ac
+      sha256: ca296ee661896990c7eaa667d5d6b208391b35ea52a786e30a1c372546fb23b6
       url: "https://pub.dev"
     source: hosted
-    version: "0.0.1-dev.3"
+    version: "0.0.1-dev.4"
   super_simple_authentication_toolkit:
     dependency: "direct main"
     description:

--- a/server/pubspec.yaml
+++ b/server/pubspec.yaml
@@ -10,7 +10,7 @@ dependencies:
   dart_frog: 1.2.6
   mason_logger: ^0.3.3
   super_simple_authentication_hive_data_storage: 0.0.1-dev.2
-  super_simple_authentication_postgres_data_storage: 0.0.1-dev.3
+  super_simple_authentication_postgres_data_storage: 0.0.1-dev.4
   super_simple_authentication_toolkit: 0.0.1-dev.8
 
 dev_dependencies:


### PR DESCRIPTION
## Changes

- Fix nullable password and salt fields in `User` type mapping for Postgres data storage
- Make `hashedPassword` and `salt` nullable when reading from database
- Update version to 0.0.1-dev.4
- Update CHANGELOG

## Testing

- ✅ Code formatted with `dart format`
- ✅ Linter passed with no errors (`dart analyze`)