### PR TITLE
feat: add SMTP email provider support

### DIFF
--- a/server/packages/super_simple_authentication_toolkit/CHANGELOG.md
+++ b/server/packages/super_simple_authentication_toolkit/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.0.1-dev.9
+
+- Add `SmtpEmailProvider` for sending emails via SMTP
+
 ## 0.0.1-dev.8
 
 - Add `expiresAt` and `expiresIn` to `sendOtpHandler` response

--- a/server/packages/super_simple_authentication_toolkit/lib/src/integrations/email/email.dart
+++ b/server/packages/super_simple_authentication_toolkit/lib/src/integrations/email/email.dart
@@ -1,3 +1,4 @@
 export 'email_provider.dart';
 export 'fake_email_service.dart';
 export 'sendgrid.dart';
+export 'smtp_email_provider.dart';

--- a/server/packages/super_simple_authentication_toolkit/lib/src/integrations/email/smtp_email_provider.dart
+++ b/server/packages/super_simple_authentication_toolkit/lib/src/integrations/email/smtp_email_provider.dart
@@ -1,0 +1,101 @@
+import 'package:mailer/mailer.dart';
+import 'package:mailer/smtp_server.dart';
+import 'package:super_simple_authentication_toolkit/super_simple_authentication_toolkit.dart';
+
+/// {@template smtp_email_provider}
+/// A client for sending emails using SMTP.
+/// {@endtemplate}
+class SmtpEmailProvider implements EmailProvider {
+  /// {@macro smtp_email_provider}
+  SmtpEmailProvider({
+    required String host,
+    required int port,
+    required String username,
+    required String password,
+    bool useSsl = true,
+    bool allowInsecure = false,
+    String? name,
+  }) : _host = host,
+       _port = port,
+       _username = username,
+       _password = password,
+       _useSsl = useSsl,
+       _allowInsecure = allowInsecure,
+       _name = name;
+
+  final String _host;
+  final int _port;
+  final String _username;
+  final String _password;
+  final bool _useSsl;
+  final bool _allowInsecure;
+  final String? _name;
+
+  SmtpServer get _smtpServer {
+    if (_useSsl) {
+      return SmtpServer(
+        _host,
+        port: _port,
+        username: _username,
+        password: _password,
+        ssl: true,
+        allowInsecure: _allowInsecure,
+        name: _name,
+      );
+    } else {
+      return SmtpServer(
+        _host,
+        port: _port,
+        username: _username,
+        password: _password,
+        allowInsecure: _allowInsecure,
+        name: _name,
+      );
+    }
+  }
+
+  /// Sends an email using SMTP.
+  ///
+  /// [to] is the email address of the recipient.
+  /// [subject] is the subject of the email.
+  /// [body] is the body of the email.
+  /// [from] is the email address of the sender.
+  @override
+  Future<void> sendEmail({
+    required String to,
+    required String subject,
+    required String body,
+    required String from,
+  }) async {
+    final message = Message()
+      ..from = Address(from)
+      ..recipients.add(to)
+      ..subject = subject
+      ..text = body;
+
+    await send(message, _smtpServer);
+  }
+
+  /// Sends an email using a template.
+  ///
+  /// **Note:** SMTP does not support dynamic templates like SendGrid.
+  /// This method will throw an [UnimplementedError] as template support
+  /// would require a custom template engine implementation.
+  ///
+  /// For template-based emails, consider using SendGrid or implementing
+  /// a custom template substitution before calling [sendEmail].
+  @override
+  Future<void> sendEmailWithTemplate({
+    required String to,
+    required String templateId,
+    required Map<String, dynamic> dynamicTemplateData,
+    required String from,
+    String? subject,
+  }) async {
+    throw UnimplementedError(
+      'SMTP does not support dynamic templates. '
+      'Use sendEmail() with pre-rendered content instead, '
+      'or use SendGrid for template support.',
+    );
+  }
+}

--- a/server/packages/super_simple_authentication_toolkit/pubspec.yaml
+++ b/server/packages/super_simple_authentication_toolkit/pubspec.yaml
@@ -1,6 +1,6 @@
 name: super_simple_authentication_toolkit
 description: A collection of Dart Frog functions that power the super_simple_authentication_server
-version: 0.0.1-dev.8
+version: 0.0.1-dev.9
 repository: https://github.com/mtwichel/super_simple_flutter_authentication/tree/main/packages/super_simple_authentication_toolkit
 
 environment:

--- a/server/packages/super_simple_authentication_toolkit/pubspec.yaml
+++ b/server/packages/super_simple_authentication_toolkit/pubspec.yaml
@@ -9,6 +9,7 @@ environment:
 dependencies:
   dart_frog: ^1.2.3
   http: ^1.5.0
+  mailer: ^6.0.1
   meta: ^1.17.0
   pointycastle: ^4.0.0
   uuid: ^4.5.1

--- a/server/pubspec.lock
+++ b/server/pubspec.lock
@@ -548,10 +548,11 @@ packages:
   super_simple_authentication_toolkit:
     dependency: "direct main"
     description:
-      path: "packages/super_simple_authentication_toolkit"
-      relative: true
-    source: path
-    version: "0.0.1-dev.8"
+      name: super_simple_authentication_toolkit
+      sha256: "158ccf8a5954d2ba31179dc1f28ee2348a699664f3d90120626bbf4c0fec9422"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.0.1-dev.9"
   term_glyph:
     dependency: transitive
     description:

--- a/server/pubspec.lock
+++ b/server/pubspec.lock
@@ -89,6 +89,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.2.0"
+  clock:
+    dependency: transitive
+    description:
+      name: clock
+      sha256: fddb70d9b5277016c77a80201021d40a2247104d9f4aa7bab7157b7e3f05b84b
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.1.2"
   collection:
     dependency: transitive
     description:
@@ -225,6 +233,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "4.1.2"
+  intl:
+    dependency: transitive
+    description:
+      name: intl
+      sha256: "3df61194eb431efc39c4ceba583b95633a403f46c9fd341e550ce0bfa50e9aa5"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.20.2"
   io:
     dependency: transitive
     description:
@@ -265,6 +281,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.3.0"
+  mailer:
+    dependency: transitive
+    description:
+      name: mailer
+      sha256: c3b934c0e800ddc946167c0123a900eba5acd009abb73648d0191a742542f2b4
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.6.0"
   mason_logger:
     dependency: "direct main"
     description:

--- a/server/pubspec.yaml
+++ b/server/pubspec.yaml
@@ -11,7 +11,7 @@ dependencies:
   mason_logger: ^0.3.3
   super_simple_authentication_hive_data_storage: 0.0.1-dev.2
   super_simple_authentication_postgres_data_storage: 0.0.1-dev.4
-  super_simple_authentication_toolkit: 0.0.1-dev.8
+  super_simple_authentication_toolkit: 0.0.1-dev.9
 
 dev_dependencies:
   json_serializable: ^6.11.3

--- a/server/routes/_middleware.dart
+++ b/server/routes/_middleware.dart
@@ -21,6 +21,16 @@ Handler middleware(Handler handler) {
               apiKey: Platform.environment['SENDGRID_API_KEY']!,
               baseUrl: Platform.environment['SENDGRID_BASE_URL']!,
             ),
+            'smtp' => SmtpEmailProvider(
+              host: Platform.environment['SMTP_HOST']!,
+              port: int.parse(Platform.environment['SMTP_PORT']!),
+              username: Platform.environment['SMTP_USERNAME']!,
+              password: Platform.environment['SMTP_PASSWORD']!,
+              useSsl: Platform.environment['SMTP_USE_SSL'] != 'false',
+              allowInsecure:
+                  Platform.environment['SMTP_ALLOW_INSECURE'] == 'true',
+              name: Platform.environment['SMTP_NAME'],
+            ),
             _ =>
               throw Exception(
                 '''Invalid email provider: ${Platform.environment['EMAIL_PROVIDER']}''',


### PR DESCRIPTION
## Summary

This PR adds SMTP email provider support to the authentication server, allowing users to send emails via any SMTP server instead of being limited to SendGrid.

## Changes

- Added `SmtpEmailProvider` class implementing the `EmailProvider` interface
- Added `mailer` package dependency (^6.0.1) for SMTP functionality
- Updated middleware to support SMTP provider selection via `EMAIL_PROVIDER=smtp` environment variable
- Added support for SSL/TLS configuration and optional insecure connections

## Configuration

To use SMTP, set the following environment variables:

```bash
export EMAIL_PROVIDER=smtp
export SMTP_HOST=smtp.example.com
export SMTP_PORT=587
export SMTP_USERNAME=your-username
export SMTP_PASSWORD=your-password
export SMTP_USE_SSL=true          # Optional, defaults to true
export SMTP_ALLOW_INSECURE=false  # Optional, defaults to false
export SMTP_NAME=                 # Optional server name
```

## Notes

- The `sendEmailWithTemplate()` method throws `UnimplementedError` for SMTP as SMTP doesn't support dynamic templates like SendGrid. For template-based emails, use SendGrid or pre-render templates before calling `sendEmail()`.
- Common SMTP ports: 587 (TLS), 465 (SSL), 25 (unencrypted, not recommended)

## Testing

- ✅ Code formatted with `dart format`
- ✅ Linter passes with no errors
- ✅ All existing email functionality remains compatible